### PR TITLE
Added improvements to p2p discovery

### DIFF
--- a/app/services/node/handlers/v1/private/private.go
+++ b/app/services/node/handlers/v1/private/private.go
@@ -89,14 +89,15 @@ func (h Handlers) ProposeBlock(ctx context.Context, w http.ResponseWriter, r *ht
 	return web.Respond(ctx, w, resp, http.StatusOK)
 }
 
-func (h Handlers) AddPeer(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
-	var p peer.Peer
+// SubmitPeer is called by a node so they can be added to the known peer list.
+func (h Handlers) SubmitPeer(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+	var peer peer.Peer
 
-	if err := web.Decode(r, &p); err != nil {
+	if err := web.Decode(r, &peer); err != nil {
 		return fmt.Errorf("unable to decode payload: %w", err)
 	}
 
-	h.State.AddKnownPeer(p)
+	h.State.AddKnownPeer(peer)
 
 	return web.Respond(ctx, w, nil, http.StatusOK)
 }

--- a/app/services/node/handlers/v1/private/private.go
+++ b/app/services/node/handlers/v1/private/private.go
@@ -96,17 +96,7 @@ func (h Handlers) AddPeer(ctx context.Context, w http.ResponseWriter, r *http.Re
 		return fmt.Errorf("unable to decode payload: %w", err)
 	}
 
-	knownPeer := false
-	for _, peer := range h.State.RetrieveKnownPeers() {
-		if peer.Match(p.Host) {
-			knownPeer = true
-			break
-		}
-	}
-
-	if !knownPeer {
-		h.State.AddKnownPeer(p)
-	}
+	h.State.AddKnownPeer(p)
 
 	return web.Respond(ctx, w, nil, http.StatusOK)
 }

--- a/app/services/node/handlers/v1/private/private.go
+++ b/app/services/node/handlers/v1/private/private.go
@@ -89,6 +89,28 @@ func (h Handlers) ProposeBlock(ctx context.Context, w http.ResponseWriter, r *ht
 	return web.Respond(ctx, w, resp, http.StatusOK)
 }
 
+func (h Handlers) AddPeer(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+	var p peer.Peer
+
+	if err := web.Decode(r, &p); err != nil {
+		return fmt.Errorf("unable to decode payload: %w", err)
+	}
+
+	knownPeer := false
+	for _, peer := range h.State.RetrieveKnownPeers() {
+		if peer.Match(p.Host) {
+			knownPeer = true
+			break
+		}
+	}
+
+	if !knownPeer {
+		h.State.AddKnownPeer(p)
+	}
+
+	return web.Respond(ctx, w, nil, http.StatusOK)
+}
+
 // Status returns the current status of the node.
 func (h Handlers) Status(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	latestBlock := h.State.RetrieveLatestBlock()

--- a/app/services/node/handlers/v1/v1.go
+++ b/app/services/node/handlers/v1/v1.go
@@ -55,7 +55,7 @@ func PrivateRoutes(app *web.App, cfg Config) {
 		NS:    cfg.NS,
 	}
 
-	app.Handle(http.MethodPost, version, "/node/peers", prv.AddPeer)
+	app.Handle(http.MethodPost, version, "/node/peers", prv.SubmitPeer)
 	app.Handle(http.MethodGet, version, "/node/status", prv.Status)
 	app.Handle(http.MethodGet, version, "/node/block/list/:from/:to", prv.BlocksByNumber)
 	app.Handle(http.MethodPost, version, "/node/block/propose", prv.ProposeBlock)

--- a/app/services/node/handlers/v1/v1.go
+++ b/app/services/node/handlers/v1/v1.go
@@ -55,6 +55,7 @@ func PrivateRoutes(app *web.App, cfg Config) {
 		NS:    cfg.NS,
 	}
 
+	app.Handle(http.MethodPost, version, "/node/peers", prv.AddPeer)
 	app.Handle(http.MethodGet, version, "/node/status", prv.Status)
 	app.Handle(http.MethodGet, version, "/node/block/list/:from/:to", prv.BlocksByNumber)
 	app.Handle(http.MethodPost, version, "/node/block/propose", prv.ProposeBlock)

--- a/app/services/node/main.go
+++ b/app/services/node/main.go
@@ -67,7 +67,7 @@ func run(log *zap.SugaredLogger) error {
 			Beneficiary    string   `conf:"default:miner1"`
 			DBPath         string   `conf:"default:zblock/miner1/"`
 			SelectStrategy string   `conf:"default:Tip"`
-			KnownPeers     []string `conf:"default:0.0.0.0:9080;0.0.0.0:9180"`
+			OriginPeers    []string `conf:"default:0.0.0.0:9080"`
 		}
 		NameService struct {
 			Folder string `conf:"default:zblock/accounts/"`
@@ -140,7 +140,7 @@ func run(log *zap.SugaredLogger) error {
 	// A peer set is a collection of known nodes in the network so transactions
 	// and blocks can be shared.
 	peerSet := peer.NewPeerSet()
-	for _, host := range cfg.State.KnownPeers {
+	for _, host := range cfg.State.OriginPeers {
 		peerSet.Add(peer.New(host))
 	}
 

--- a/foundation/blockchain/peer/peer.go
+++ b/foundation/blockchain/peer/peer.go
@@ -60,6 +60,14 @@ func (ps *PeerSet) Add(peer Peer) bool {
 	return false
 }
 
+// Remove removes a node from the set.
+func (ps *PeerSet) Remove(peer Peer) {
+	ps.mu.Lock()
+	defer ps.mu.Unlock()
+
+	delete(ps.set, peer)
+}
+
 // Copy returns a list of the known peers.
 func (ps *PeerSet) Copy(host string) []Peer {
 	ps.mu.RLock()

--- a/foundation/blockchain/state/cud.go
+++ b/foundation/blockchain/state/cud.go
@@ -5,11 +5,14 @@ import (
 	"github.com/ardanlabs/blockchain/foundation/blockchain/peer"
 )
 
-// AddKnownPeer provides the ability to add a new peer.
+// AddKnownPeer provides the ability to add a new peer to
+// the known peer list.
 func (s *State) AddKnownPeer(peer peer.Peer) bool {
 	return s.knownPeers.Add(peer)
 }
 
+// RemoveKnownPeer provides the ability to remove a peer from
+// the known peer list.
 func (s *State) RemoveKnownPeer(peer peer.Peer) {
 	s.knownPeers.Remove(peer)
 }

--- a/foundation/blockchain/state/cud.go
+++ b/foundation/blockchain/state/cud.go
@@ -10,6 +10,10 @@ func (s *State) AddKnownPeer(peer peer.Peer) bool {
 	return s.knownPeers.Add(peer)
 }
 
+func (s *State) RemoveKnownPeer(peer peer.Peer) {
+	s.knownPeers.Remove(peer)
+}
+
 // UpsertMempool adds a new transaction to the mempool.
 func (s *State) UpsertMempool(tx database.BlockTx) error {
 	return s.mempool.Upsert(tx)

--- a/foundation/blockchain/state/network.go
+++ b/foundation/blockchain/state/network.go
@@ -74,6 +74,17 @@ func (s *State) NetRequestPeerStatus(pr peer.Peer) (peer.PeerStatus, error) {
 	return ps, nil
 }
 
+// NetRequestAddPeer registers the current host state with the given peer.Peer.
+func (s *State) NetRequestAddPeer(pr peer.Peer) error {
+	s.evHandler("state: NetRequestAddPeer: started: %s", pr)
+	defer s.evHandler("state: NetRequestAddPeer: completed: %s", pr)
+
+	url := fmt.Sprintf("%s/peers", fmt.Sprintf(baseURL, pr.Host))
+	host := peer.Peer{Host: s.RetrieveHost()}
+
+	return send(http.MethodPost, url, host, nil)
+}
+
 // NetRequestPeerMempool asks the peer for the transactions in their mempool.
 func (s *State) NetRequestPeerMempool(pr peer.Peer) ([]database.BlockTx, error) {
 	s.evHandler("state: NetRequestPeerMempool: started: %s", pr)

--- a/foundation/blockchain/worker/peer.go
+++ b/foundation/blockchain/worker/peer.go
@@ -35,10 +35,18 @@ func (w *Worker) runPeersOperation() {
 		peerStatus, err := w.state.NetRequestPeerStatus(peer)
 		if err != nil {
 			w.evHandler("worker: runPeersOperation: queryPeerStatus: %s: ERROR: %s", peer.Host, err)
+			w.state.RemoveKnownPeer(peer)
 		}
 
 		// Add new peers to this nodes list.
 		w.addNewPeers(peerStatus.KnownPeers)
+	}
+
+	// get the latest peers and let them know this node is available to chat
+	for _, peer := range w.state.RetrieveKnownPeers() {
+		if err := w.state.NetRequestAddPeer(peer); err != nil {
+			w.evHandler("worker: runPeersOperation: addPeer: %s: ERROR: %s", peer.Host, err)
+		}
 	}
 }
 

--- a/foundation/blockchain/worker/sync.go
+++ b/foundation/blockchain/worker/sync.go
@@ -35,4 +35,11 @@ func (w *Worker) Sync() {
 			}
 		}
 	}
+
+	// get the latest peers and let them know this node is available to chat
+	for _, peer := range w.state.RetrieveKnownPeers() {
+		if err := w.state.NetRequestAddPeer(peer); err != nil {
+			w.evHandler("worker: runPeersOperation: addPeer: %s: ERROR: %s", peer.Host, err)
+		}
+	}
 }

--- a/foundation/blockchain/worker/sync.go
+++ b/foundation/blockchain/worker/sync.go
@@ -36,10 +36,6 @@ func (w *Worker) Sync() {
 		}
 	}
 
-	// get the latest peers and let them know this node is available to chat
-	for _, peer := range w.state.RetrieveKnownPeers() {
-		if err := w.state.NetRequestAddPeer(peer); err != nil {
-			w.evHandler("worker: runPeersOperation: addPeer: %s: ERROR: %s", peer.Host, err)
-		}
-	}
+	// Share with peers this node is available to participate in the network.
+	w.state.NetSendNodeAvailableToPeers()
 }

--- a/zarf/docker/docker-compose.yml
+++ b/zarf/docker/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     <<: *node
     container_name: blockchain-node-1
     environment:
-      NODE_STATE_KNOWN_PEERS: "blockchain-node-1:9080"
+      NODE_STATE_ORIGIN_PEERS: "blockchain-node-1:9080"
       NODE_STATE_BENEFICIARY: miner1
       NODE_WEB_PUBLIC_HOST: blockchain-node-1:8080
       NODE_WEB_PRIVATE_HOST: blockchain-node-1:9080
@@ -44,7 +44,7 @@ services:
     command: |
       bash -c "/scripts/wait-for-master-node.sh make up"
     environment:
-      NODE_STATE_KNOWN_PEERS: "blockchain-node-1:9080"
+      NODE_STATE_ORIGIN_PEERS: "blockchain-node-1:9080"
       NODE_STATE_BENEFICIARY: miner2
       NODE_WEB_PUBLIC_HOST: blockchain-node-2:8280
       NODE_WEB_PRIVATE_HOST: blockchain-node-2:9280
@@ -60,7 +60,7 @@ services:
     command: |
       bash -c "/scripts/wait-for-master-node.sh make up"
     environment:
-      NODE_STATE_KNOWN_PEERS: "blockchain-node-1:9080"
+      NODE_STATE_ORIGIN_PEERS: "blockchain-node-1:9080"
       NODE_STATE_BENEFICIARY: jeremy
       NODE_WEB_PUBLIC_HOST: blockchain-node-3:8380
       NODE_WEB_PRIVATE_HOST: blockchain-node-3:9380

--- a/zarf/docker/docker-compose.yml
+++ b/zarf/docker/docker-compose.yml
@@ -15,9 +15,10 @@ version: "3.9"
 x-node-config: &node
   image: golang:1.18
   command: |
-    sh -c "go run app/services/node/main.go -race | go run app/tooling/logfmt/main.go"
+    bash -c "make up"
   volumes:
     - ../../:/source
+    - .:/scripts
   working_dir: /source
 
 services:
@@ -26,7 +27,7 @@ services:
     <<: *node
     container_name: blockchain-node-1
     environment:
-      NODE_STATE_KNOWN_PEERS: "blockchain-node-1:9080;blockchain-node-2:9280;blockchain-node-3:9380"
+      NODE_STATE_KNOWN_PEERS: "blockchain-node-1:9080"
       NODE_STATE_BENEFICIARY: miner1
       NODE_WEB_PUBLIC_HOST: blockchain-node-1:8080
       NODE_WEB_PRIVATE_HOST: blockchain-node-1:9080
@@ -40,8 +41,10 @@ services:
   node-2:
     <<: *node
     container_name: blockchain-node-2
+    command: |
+      bash -c "/scripts/wait-for-master-node.sh make up"
     environment:
-      NODE_STATE_KNOWN_PEERS: "blockchain-node-1:9080;blockchain-node-2:9280;blockchain-node-3:9380"
+      NODE_STATE_KNOWN_PEERS: "blockchain-node-1:9080"
       NODE_STATE_BENEFICIARY: miner2
       NODE_WEB_PUBLIC_HOST: blockchain-node-2:8280
       NODE_WEB_PRIVATE_HOST: blockchain-node-2:9280
@@ -54,8 +57,10 @@ services:
   node-3:
     <<: *node
     container_name: blockchain-node-3
+    command: |
+      bash -c "/scripts/wait-for-master-node.sh make up"
     environment:
-      NODE_STATE_KNOWN_PEERS: "blockchain-node-1:9080;blockchain-node-2:9280;blockchain-node-3:9380"
+      NODE_STATE_KNOWN_PEERS: "blockchain-node-1:9080"
       NODE_STATE_BENEFICIARY: jeremy
       NODE_WEB_PUBLIC_HOST: blockchain-node-3:8380
       NODE_WEB_PRIVATE_HOST: blockchain-node-3:9380

--- a/zarf/docker/wait-for-master-node.sh
+++ b/zarf/docker/wait-for-master-node.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# wait-for-masster-node.sh
+
+set -e
+  
+until curl blockchain-node-1:9080/v1/node/status >> /dev/null; do
+  >&2 echo "Master node is unavailable - sleeping"
+  sleep 1
+done
+  
+>&2 echo "Master node is up - executing command"
+exec "$@"


### PR DESCRIPTION
This PR adds better support for p2p discovery for blockchain nodes. Nodes will now reach out to known peers to make themselves known. Since nodes are now chatty around their presence, we can easily remove unresponsive nodes.

This obviously isn't a production-ready implementation, as there are plenty of inefficiencies with this discovery mechanism, but its effective enough for demonstration purposes.

## See The Demo
[![asciicast](https://asciinema.org/a/490924.svg)](https://asciinema.org/a/490924)


## What Changed

- Added the ability to register oneself as a known peer for all of yourpeers.
- Added peer removal in the case of a failed status.
- Improved dockerfile and added checks for master node before starting secondary nodes.
