### PR TITLE
changing path to filepath to make it work on windows

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -19,6 +19,7 @@
 # Please keep the list sorted.
 
 Bruno Belucci <bruno.belucci@ardanlabs.com>
+Halil İbrahim Yıldırım <halilgolang@gmail.com>
 Jeremy Saenz <jeremy.saenz@gmail.com>
 Paulo Simão <paulo.simao@ardanlabs.com>
 Pavel Aborilov <pavel.aborilov@ardanlabs.com>

--- a/foundation/nameservice/nameservice.go
+++ b/foundation/nameservice/nameservice.go
@@ -39,7 +39,7 @@ func New(root string) (*NameService, error) {
 		}
 
 		accountID := database.PublicKeyToAccountID(privateKey.PublicKey)
-		ns.accounts[accountID] = strings.TrimSuffix(path.Base(fileName), ".ecdsa")
+		ns.accounts[accountID] = strings.TrimSuffix(filepath.Base(fileName), ".ecdsa")
 
 		return nil
 	}


### PR DESCRIPTION
Hello,
path.Base does not properly work on Windows so I changed it into filepath.Base. I think path.Base cannot recognize windows path as it has seperator " \ " instead of "/" 